### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,7 +14,7 @@ IRLremote	KEYWORD1
 
 CNec	KEYWORD2
 CNecAPI	KEYWORD2
-CPanasonic KEYWORD2
+CPanasonic	KEYWORD2
 CHashIR	KEYWORD2
 Nec_data_t	KEYWORD2
 Panasonic_data_t	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords